### PR TITLE
编译时将bundles写入require-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 node_modules*
 prd/
 app/static/js/lib
+*.swp

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -156,7 +156,9 @@ module.exports = function (grunt) {
     rev: require('./config/grunt/rev'),
 
     // 删除已经打包的requirejs插件资源文件
-    removeCombined: require('./config/grunt/removeCombined')
+    removeCombined: require('./config/grunt/removeCombined'),
+		
+    replace: require('./config/grunt/replace')
 
   };
 
@@ -214,6 +216,7 @@ module.exports = function (grunt) {
     'autoprefixer:dist',
     'concat',
     'requirejs',
+	'replace',
     'removeCombined',
     'uglify',
     'cssmin',

--- a/app/static/js/common/require-config.js
+++ b/app/static/js/common/require-config.js
@@ -47,6 +47,8 @@ var require = {
   }
 };
 
+/* _bundles_position */
+
 if ( typeof module === 'object' && typeof module.exports === 'object' ) {
   module.exports = {
     paths: require.paths,

--- a/app/static/js/pages/demo/main.js
+++ b/app/static/js/pages/demo/main.js
@@ -1,7 +1,3 @@
 'use strict';
 
-require([
-	'common/lib'
-  ], function() {
-  	require(['pages/demo/index']);
-});
+require(['pages/demo/index']);

--- a/config/grunt/replace.js
+++ b/config/grunt/replace.js
@@ -1,0 +1,15 @@
+var bundle = require('../bundle') || {};
+
+module.exports =  {
+	default: {
+		src: '<%=yo.dist%>/static/js/common/require-config.js',
+		overwrite: true,
+		replacements: [{
+			from: /\/\*\s*_bundles_position\s*\*\//,
+			to: function() {
+				var bundleString = JSON.stringify(bundle);
+				return 'require.bundles=' + bundleString + ';';
+			}
+		}]
+	}
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "grunt-contrib-concat": "0.5.0",
     "grunt-contrib-copy": "0.7.0",
     "grunt-contrib-cssmin": "0.11.0",
-    "grunt-contrib-imagemin": "0.9.2",
+    "grunt-contrib-imagemin": "0.9.4",
     "grunt-contrib-jshint": "0.10.0",
     "grunt-contrib-less": "1.0.0",
     "grunt-contrib-requirejs": "0.4.4",
@@ -20,7 +20,8 @@
     "jshint-stylish": "1.0.0",
     "matchdep": "0.3.0",
     "requirejs-babel": "0.0.6",
-    "time-grunt": "1.0.0"
+    "time-grunt": "1.0.0",
+    "grunt-text-replace": "~0.4.0"
   },
   "devDependencies": {
     "grunt-connect-route": "0.3.1",


### PR DESCRIPTION
编译时将bundles写入require-config，解决打包后require合并前module报错的问题
